### PR TITLE
Add a Mutex lock around env changes and dependent tests.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,9 @@ envmnt = "^0.7"
 serde = { version = "1", optional = true }
 serde_derive = { version = "1", optional = true }
 
+[dev-dependencies]
+lazy_static = "^1"
+
 [features]
 serde-1 = [ "serde", "serde_derive" ]
 

--- a/src/ci_test.rs
+++ b/src/ci_test.rs
@@ -1,72 +1,8 @@
 use super::*;
 
+use crate::test_env::setup_env;
+
 use std::env;
-
-fn setup_env(vars: Vec<(&str, &str)>) {
-    envmnt::remove_all(&vec![
-        "APPVEYOR",
-        "APPVEYOR_PULL_REQUEST_NUMBER",
-        "SYSTEM_TEAMFOUNDATIONCOLLECTIONURI",
-        "SYSTEM_PULLREQUEST_PULLREQUESTID",
-        "bamboo_planKey",
-        "BITBUCKET_COMMIT",
-        "BITBUCKET_PR_ID",
-        "BITRISE_IO",
-        "BITRISE_PULL_REQUEST",
-        "BUDDY_WORKSPACE_ID",
-        "BUDDY_EXECUTION_PULL_REQUEST_ID",
-        "BUILDKITE",
-        "BUILDKITE_PULL_REQUEST",
-        "CIRCLECI",
-        "CIRCLE_PULL_REQUEST",
-        "CIRRUS_CI",
-        "CIRRUS_PR",
-        "CODEBUILD_BUILD_ARN",
-        "CI_NAME",
-        "DRONE",
-        "DRONE_BUILD_EVENT",
-        "pull_request",
-        "DSARI",
-        "GITHUB_ACTIONS",
-        "GITHUB_EVENT_NAME",
-        "GITLAB_CI",
-        "GO_PIPELINE_LABEL",
-        "NODE",
-        "HUDSON_URL",
-        "JENKINS_URL",
-        "BUILD_ID",
-        "ghprbPullId",
-        "CHANGE_ID",
-        "MAGNUM",
-        "NETLIFY_BUILD_BASE",
-        "PULL_REQUEST",
-        "NEVERCODE",
-        "NEVERCODE_PULL_REQUEST",
-        "RENDER",
-        "SAILCI",
-        "SAIL_PULL_REQUEST_NUMBER",
-        "SEMAPHORE",
-        "PULL_REQUEST_NUMBER",
-        "SHIPPABLE",
-        "IS_PULL_REQUEST",
-        "TDDIUM",
-        "TDDIUM_PR_ID",
-        "STRIDER",
-        "TASK_ID",
-        "RUN_ID",
-        "TEAMCITY_VERSION",
-        "TRAVIS",
-        "TRAVIS_PULL_REQUEST",
-        "NOW_BUILDER",
-        "CI",
-        "CONTINUOUS_INTEGRATION",
-        "BUILD_NUMBER",
-    ]);
-
-    for env_var in vars {
-        env::set_var(env_var.0, env_var.1);
-    }
-}
 
 #[test]
 fn validate_exists_true() {
@@ -210,6 +146,7 @@ fn validate_contains_not_exists() {
 
 #[test]
 fn is_ci_test() {
+    let _lock = setup_env(vec![]);
     let info = get();
     let ci = is_ci();
 
@@ -218,6 +155,7 @@ fn is_ci_test() {
 
 #[test]
 fn get_test() {
+    let _lock = setup_env(vec![]);
     let info = get();
 
     assert_eq!(info.name.is_some(), info.vendor.is_some());
@@ -225,7 +163,7 @@ fn get_test() {
 
 #[test]
 fn get_no_pr_appveyor() {
-    setup_env(vec![("APPVEYOR", "")]);
+    let _lock = setup_env(vec![("APPVEYOR", "")]);
 
     let info = get();
 
@@ -237,7 +175,7 @@ fn get_no_pr_appveyor() {
 
 #[test]
 fn get_pr_appveyor() {
-    setup_env(vec![("APPVEYOR", ""), ("APPVEYOR_PULL_REQUEST_NUMBER", "")]);
+    let _lock = setup_env(vec![("APPVEYOR", ""), ("APPVEYOR_PULL_REQUEST_NUMBER", "")]);
 
     let info = get();
 
@@ -249,7 +187,7 @@ fn get_pr_appveyor() {
 
 #[test]
 fn get_no_pr_azure_piplines() {
-    setup_env(vec![("SYSTEM_TEAMFOUNDATIONCOLLECTIONURI", "")]);
+    let _lock = setup_env(vec![("SYSTEM_TEAMFOUNDATIONCOLLECTIONURI", "")]);
 
     let info = get();
 
@@ -261,7 +199,7 @@ fn get_no_pr_azure_piplines() {
 
 #[test]
 fn get_pr_azure_piplines() {
-    setup_env(vec![
+    let _lock = setup_env(vec![
         ("SYSTEM_TEAMFOUNDATIONCOLLECTIONURI", ""),
         ("SYSTEM_PULLREQUEST_PULLREQUESTID", ""),
     ]);
@@ -276,7 +214,7 @@ fn get_pr_azure_piplines() {
 
 #[test]
 fn get_bamboo() {
-    setup_env(vec![("bamboo_planKey", "")]);
+    let _lock = setup_env(vec![("bamboo_planKey", "")]);
 
     let info = get();
 
@@ -288,7 +226,7 @@ fn get_bamboo() {
 
 #[test]
 fn get_no_pr_bitbucket_piplines() {
-    setup_env(vec![("BITBUCKET_COMMIT", "")]);
+    let _lock = setup_env(vec![("BITBUCKET_COMMIT", "")]);
 
     let info = get();
 
@@ -300,7 +238,7 @@ fn get_no_pr_bitbucket_piplines() {
 
 #[test]
 fn get_pr_bitbucket_piplines() {
-    setup_env(vec![("BITBUCKET_COMMIT", ""), ("BITBUCKET_PR_ID", "")]);
+    let _lock = setup_env(vec![("BITBUCKET_COMMIT", ""), ("BITBUCKET_PR_ID", "")]);
 
     let info = get();
 
@@ -312,7 +250,7 @@ fn get_pr_bitbucket_piplines() {
 
 #[test]
 fn get_no_pr_bitrise() {
-    setup_env(vec![("BITRISE_IO", "")]);
+    let _lock = setup_env(vec![("BITRISE_IO", "")]);
 
     let info = get();
 
@@ -324,7 +262,7 @@ fn get_no_pr_bitrise() {
 
 #[test]
 fn get_pr_bitrise() {
-    setup_env(vec![("BITRISE_IO", ""), ("BITRISE_PULL_REQUEST", "")]);
+    let _lock = setup_env(vec![("BITRISE_IO", ""), ("BITRISE_PULL_REQUEST", "")]);
 
     let info = get();
 
@@ -336,7 +274,7 @@ fn get_pr_bitrise() {
 
 #[test]
 fn get_no_pr_buddy() {
-    setup_env(vec![("BUDDY_WORKSPACE_ID", "")]);
+    let _lock = setup_env(vec![("BUDDY_WORKSPACE_ID", "")]);
 
     let info = get();
 
@@ -348,7 +286,7 @@ fn get_no_pr_buddy() {
 
 #[test]
 fn get_pr_buddy() {
-    setup_env(vec![
+    let _lock = setup_env(vec![
         ("BUDDY_WORKSPACE_ID", ""),
         ("BUDDY_EXECUTION_PULL_REQUEST_ID", ""),
     ]);
@@ -363,7 +301,7 @@ fn get_pr_buddy() {
 
 #[test]
 fn get_no_pr_buildkite() {
-    setup_env(vec![("BUILDKITE", ""), ("BUILDKITE_PULL_REQUEST", "false")]);
+    let _lock = setup_env(vec![("BUILDKITE", ""), ("BUILDKITE_PULL_REQUEST", "false")]);
 
     let info = get();
 
@@ -375,7 +313,7 @@ fn get_no_pr_buildkite() {
 
 #[test]
 fn get_pr_buildkite() {
-    setup_env(vec![("BUILDKITE", ""), ("BUILDKITE_PULL_REQUEST", "123")]);
+    let _lock = setup_env(vec![("BUILDKITE", ""), ("BUILDKITE_PULL_REQUEST", "123")]);
 
     let info = get();
 
@@ -387,7 +325,7 @@ fn get_pr_buildkite() {
 
 #[test]
 fn get_pr2_buildkite() {
-    setup_env(vec![("BUILDKITE", "")]);
+    let _lock = setup_env(vec![("BUILDKITE", "")]);
 
     let info = get();
 
@@ -399,7 +337,7 @@ fn get_pr2_buildkite() {
 
 #[test]
 fn get_no_pr_circle_ci() {
-    setup_env(vec![("CIRCLECI", "")]);
+    let _lock = setup_env(vec![("CIRCLECI", "")]);
 
     let info = get();
 
@@ -411,7 +349,7 @@ fn get_no_pr_circle_ci() {
 
 #[test]
 fn get_pr_circle_ci() {
-    setup_env(vec![("CIRCLECI", ""), ("CIRCLE_PULL_REQUEST", "")]);
+    let _lock = setup_env(vec![("CIRCLECI", ""), ("CIRCLE_PULL_REQUEST", "")]);
 
     let info = get();
 
@@ -423,7 +361,7 @@ fn get_pr_circle_ci() {
 
 #[test]
 fn get_no_pr_cirrus_ci() {
-    setup_env(vec![("CIRRUS_CI", "")]);
+    let _lock = setup_env(vec![("CIRRUS_CI", "")]);
 
     let info = get();
 
@@ -435,7 +373,7 @@ fn get_no_pr_cirrus_ci() {
 
 #[test]
 fn get_pr_cirrus_ci() {
-    setup_env(vec![("CIRRUS_CI", ""), ("CIRRUS_PR", "")]);
+    let _lock = setup_env(vec![("CIRRUS_CI", ""), ("CIRRUS_PR", "")]);
 
     let info = get();
 
@@ -447,7 +385,7 @@ fn get_pr_cirrus_ci() {
 
 #[test]
 fn get_aws_codebuild() {
-    setup_env(vec![("CODEBUILD_BUILD_ARN", "")]);
+    let _lock = setup_env(vec![("CODEBUILD_BUILD_ARN", "")]);
 
     let info = get();
 
@@ -459,7 +397,7 @@ fn get_aws_codebuild() {
 
 #[test]
 fn get_codeship() {
-    setup_env(vec![("CI_NAME", "codeship")]);
+    let _lock = setup_env(vec![("CI_NAME", "codeship")]);
 
     let info = get();
 
@@ -471,7 +409,7 @@ fn get_codeship() {
 
 #[test]
 fn get_no_pr_drone() {
-    setup_env(vec![("DRONE", "")]);
+    let _lock = setup_env(vec![("DRONE", "")]);
 
     let info = get();
 
@@ -483,7 +421,7 @@ fn get_no_pr_drone() {
 
 #[test]
 fn get_no_pr2_drone() {
-    setup_env(vec![("DRONE", ""), ("DRONE_BUILD_EVENT", "test")]);
+    let _lock = setup_env(vec![("DRONE", ""), ("DRONE_BUILD_EVENT", "test")]);
 
     let info = get();
 
@@ -495,7 +433,7 @@ fn get_no_pr2_drone() {
 
 #[test]
 fn get_pr_drone() {
-    setup_env(vec![("DRONE", ""), ("DRONE_BUILD_EVENT", "pull_request")]);
+    let _lock = setup_env(vec![("DRONE", ""), ("DRONE_BUILD_EVENT", "pull_request")]);
 
     let info = get();
 
@@ -507,7 +445,7 @@ fn get_pr_drone() {
 
 #[test]
 fn get_dsari() {
-    setup_env(vec![("DSARI", "")]);
+    let _lock = setup_env(vec![("DSARI", "")]);
 
     let info = get();
 
@@ -519,7 +457,7 @@ fn get_dsari() {
 
 #[test]
 fn get_no_pr_github_actions() {
-    setup_env(vec![("GITHUB_ACTIONS", "")]);
+    let _lock = setup_env(vec![("GITHUB_ACTIONS", "")]);
 
     let info = get();
 
@@ -531,7 +469,7 @@ fn get_no_pr_github_actions() {
 
 #[test]
 fn get_no_pr2_github_actions() {
-    setup_env(vec![("GITHUB_ACTIONS", ""), ("GITHUB_EVENT_NAME", "test")]);
+    let _lock = setup_env(vec![("GITHUB_ACTIONS", ""), ("GITHUB_EVENT_NAME", "test")]);
 
     let info = get();
 
@@ -543,7 +481,7 @@ fn get_no_pr2_github_actions() {
 
 #[test]
 fn get_pr_github_actions() {
-    setup_env(vec![
+    let _lock = setup_env(vec![
         ("GITHUB_ACTIONS", ""),
         ("GITHUB_EVENT_NAME", "pull_request"),
     ]);
@@ -558,7 +496,7 @@ fn get_pr_github_actions() {
 
 #[test]
 fn get_gitlab_ci() {
-    setup_env(vec![("GITLAB_CI", "")]);
+    let _lock = setup_env(vec![("GITLAB_CI", "")]);
 
     let info = get();
 
@@ -570,7 +508,7 @@ fn get_gitlab_ci() {
 
 #[test]
 fn get_gocd() {
-    setup_env(vec![("GO_PIPELINE_LABEL", "")]);
+    let _lock = setup_env(vec![("GO_PIPELINE_LABEL", "")]);
 
     let info = get();
 
@@ -582,7 +520,7 @@ fn get_gocd() {
 
 #[test]
 fn get_heroku() {
-    setup_env(vec![("NODE", "/app/.heroku/node/bin/node")]);
+    let _lock = setup_env(vec![("NODE", "/app/.heroku/node/bin/node")]);
 
     let info = get();
 
@@ -594,7 +532,7 @@ fn get_heroku() {
 
 #[test]
 fn get_heroku_not_ci() {
-    setup_env(vec![("NODE", "test")]);
+    let _lock = setup_env(vec![("NODE", "test")]);
 
     let info = get();
 
@@ -603,7 +541,7 @@ fn get_heroku_not_ci() {
 
 #[test]
 fn get_hudson() {
-    setup_env(vec![("HUDSON_URL", "")]);
+    let _lock = setup_env(vec![("HUDSON_URL", "")]);
 
     let info = get();
 
@@ -615,7 +553,7 @@ fn get_hudson() {
 
 #[test]
 fn get_no_pr_jenkins() {
-    setup_env(vec![("JENKINS_URL", ""), ("BUILD_ID", "")]);
+    let _lock = setup_env(vec![("JENKINS_URL", ""), ("BUILD_ID", "")]);
 
     let info = get();
 
@@ -627,7 +565,7 @@ fn get_no_pr_jenkins() {
 
 #[test]
 fn get_partial1_jenkins() {
-    setup_env(vec![("JENKINS_URL", "")]);
+    let _lock = setup_env(vec![("JENKINS_URL", "")]);
 
     let info = get();
 
@@ -638,7 +576,7 @@ fn get_partial1_jenkins() {
 
 #[test]
 fn get_partial2_jenkins() {
-    setup_env(vec![("BUILD_ID", "")]);
+    let _lock = setup_env(vec![("BUILD_ID", "")]);
 
     let info = get();
 
@@ -649,7 +587,7 @@ fn get_partial2_jenkins() {
 
 #[test]
 fn get_pr_jenkins() {
-    setup_env(vec![
+    let _lock = setup_env(vec![
         ("JENKINS_URL", ""),
         ("BUILD_ID", ""),
         ("ghprbPullId", ""),
@@ -665,7 +603,7 @@ fn get_pr_jenkins() {
 
 #[test]
 fn get_pr2_jenkins() {
-    setup_env(vec![
+    let _lock = setup_env(vec![
         ("JENKINS_URL", ""),
         ("BUILD_ID", ""),
         ("CHANGE_ID", ""),
@@ -681,7 +619,7 @@ fn get_pr2_jenkins() {
 
 #[test]
 fn get_magnum_ci() {
-    setup_env(vec![("MAGNUM", "")]);
+    let _lock = setup_env(vec![("MAGNUM", "")]);
 
     let info = get();
 
@@ -693,7 +631,7 @@ fn get_magnum_ci() {
 
 #[test]
 fn get_no_pr_netlify_ci() {
-    setup_env(vec![("NETLIFY_BUILD_BASE", ""), ("PULL_REQUEST", "false")]);
+    let _lock = setup_env(vec![("NETLIFY_BUILD_BASE", ""), ("PULL_REQUEST", "false")]);
 
     let info = get();
 
@@ -705,7 +643,7 @@ fn get_no_pr_netlify_ci() {
 
 #[test]
 fn get_pr_netlify_ci() {
-    setup_env(vec![("NETLIFY_BUILD_BASE", ""), ("PULL_REQUEST", "123")]);
+    let _lock = setup_env(vec![("NETLIFY_BUILD_BASE", ""), ("PULL_REQUEST", "123")]);
 
     let info = get();
 
@@ -717,7 +655,7 @@ fn get_pr_netlify_ci() {
 
 #[test]
 fn get_pr2_netlify_ci() {
-    setup_env(vec![("NETLIFY_BUILD_BASE", "")]);
+    let _lock = setup_env(vec![("NETLIFY_BUILD_BASE", "")]);
 
     let info = get();
 
@@ -729,7 +667,7 @@ fn get_pr2_netlify_ci() {
 
 #[test]
 fn get_no_pr_nevercode_ci() {
-    setup_env(vec![("NEVERCODE", ""), ("NEVERCODE_PULL_REQUEST", "false")]);
+    let _lock = setup_env(vec![("NEVERCODE", ""), ("NEVERCODE_PULL_REQUEST", "false")]);
 
     let info = get();
 
@@ -741,7 +679,7 @@ fn get_no_pr_nevercode_ci() {
 
 #[test]
 fn get_pr_nevercode_ci() {
-    setup_env(vec![("NEVERCODE", ""), ("NEVERCODE_PULL_REQUEST", "123")]);
+    let _lock = setup_env(vec![("NEVERCODE", ""), ("NEVERCODE_PULL_REQUEST", "123")]);
 
     let info = get();
 
@@ -753,7 +691,7 @@ fn get_pr_nevercode_ci() {
 
 #[test]
 fn get_pr2_nevercode_ci() {
-    setup_env(vec![("NEVERCODE", "")]);
+    let _lock = setup_env(vec![("NEVERCODE", "")]);
 
     let info = get();
 
@@ -765,7 +703,7 @@ fn get_pr2_nevercode_ci() {
 
 #[test]
 fn get_no_pr_render_ci() {
-    setup_env(vec![("RENDER", "")]);
+    let _lock = setup_env(vec![("RENDER", "")]);
 
     let info = get();
 
@@ -777,7 +715,7 @@ fn get_no_pr_render_ci() {
 
 #[test]
 fn get_pr_render_ci() {
-    setup_env(vec![("RENDER", ""), ("IS_PULL_REQUEST", "true")]);
+    let _lock = setup_env(vec![("RENDER", ""), ("IS_PULL_REQUEST", "true")]);
 
     let info = get();
 
@@ -789,7 +727,7 @@ fn get_pr_render_ci() {
 
 #[test]
 fn get_no_pr_sail_ci() {
-    setup_env(vec![("SAILCI", "")]);
+    let _lock = setup_env(vec![("SAILCI", "")]);
 
     let info = get();
 
@@ -801,7 +739,7 @@ fn get_no_pr_sail_ci() {
 
 #[test]
 fn get_pr_sail_ci() {
-    setup_env(vec![("SAILCI", ""), ("SAIL_PULL_REQUEST_NUMBER", "")]);
+    let _lock = setup_env(vec![("SAILCI", ""), ("SAIL_PULL_REQUEST_NUMBER", "")]);
 
     let info = get();
 
@@ -813,7 +751,7 @@ fn get_pr_sail_ci() {
 
 #[test]
 fn get_no_pr_semaphore() {
-    setup_env(vec![("SEMAPHORE", "")]);
+    let _lock = setup_env(vec![("SEMAPHORE", "")]);
 
     let info = get();
 
@@ -825,7 +763,7 @@ fn get_no_pr_semaphore() {
 
 #[test]
 fn get_pr_semaphore() {
-    setup_env(vec![("SEMAPHORE", ""), ("PULL_REQUEST_NUMBER", "")]);
+    let _lock = setup_env(vec![("SEMAPHORE", ""), ("PULL_REQUEST_NUMBER", "")]);
 
     let info = get();
 
@@ -837,7 +775,7 @@ fn get_pr_semaphore() {
 
 #[test]
 fn get_no_pr_shippable() {
-    setup_env(vec![("SHIPPABLE", "")]);
+    let _lock = setup_env(vec![("SHIPPABLE", "")]);
 
     let info = get();
 
@@ -849,7 +787,7 @@ fn get_no_pr_shippable() {
 
 #[test]
 fn get_no_pr2_shippable() {
-    setup_env(vec![("SHIPPABLE", ""), ("IS_PULL_REQUEST", "123")]);
+    let _lock = setup_env(vec![("SHIPPABLE", ""), ("IS_PULL_REQUEST", "123")]);
 
     let info = get();
 
@@ -861,7 +799,7 @@ fn get_no_pr2_shippable() {
 
 #[test]
 fn get_pr_shippable() {
-    setup_env(vec![("SHIPPABLE", ""), ("IS_PULL_REQUEST", "true")]);
+    let _lock = setup_env(vec![("SHIPPABLE", ""), ("IS_PULL_REQUEST", "true")]);
 
     let info = get();
 
@@ -873,7 +811,7 @@ fn get_pr_shippable() {
 
 #[test]
 fn get_no_pr_solano_ci() {
-    setup_env(vec![("TDDIUM", "")]);
+    let _lock = setup_env(vec![("TDDIUM", "")]);
 
     let info = get();
 
@@ -885,7 +823,7 @@ fn get_no_pr_solano_ci() {
 
 #[test]
 fn get_pr_solano_ci() {
-    setup_env(vec![("TDDIUM", ""), ("TDDIUM_PR_ID", "")]);
+    let _lock = setup_env(vec![("TDDIUM", ""), ("TDDIUM_PR_ID", "")]);
 
     let info = get();
 
@@ -897,7 +835,7 @@ fn get_pr_solano_ci() {
 
 #[test]
 fn get_strider_cd() {
-    setup_env(vec![("STRIDER", "")]);
+    let _lock = setup_env(vec![("STRIDER", "")]);
 
     let info = get();
 
@@ -909,7 +847,7 @@ fn get_strider_cd() {
 
 #[test]
 fn get_taskcluster() {
-    setup_env(vec![("TASK_ID", ""), ("RUN_ID", "")]);
+    let _lock = setup_env(vec![("TASK_ID", ""), ("RUN_ID", "")]);
 
     let info = get();
 
@@ -921,7 +859,7 @@ fn get_taskcluster() {
 
 #[test]
 fn get_partial1_taskcluster() {
-    setup_env(vec![("TASK_ID", "")]);
+    let _lock = setup_env(vec![("TASK_ID", "")]);
 
     let info = get();
 
@@ -932,7 +870,7 @@ fn get_partial1_taskcluster() {
 
 #[test]
 fn get_partial2_taskcluster() {
-    setup_env(vec![("RUN_ID", "")]);
+    let _lock = setup_env(vec![("RUN_ID", "")]);
 
     let info = get();
 
@@ -943,7 +881,7 @@ fn get_partial2_taskcluster() {
 
 #[test]
 fn get_teamcity() {
-    setup_env(vec![("TEAMCITY_VERSION", "")]);
+    let _lock = setup_env(vec![("TEAMCITY_VERSION", "")]);
 
     let info = get();
 
@@ -955,7 +893,7 @@ fn get_teamcity() {
 
 #[test]
 fn get_no_pr_travis() {
-    setup_env(vec![("TRAVIS", ""), ("TRAVIS_PULL_REQUEST", "false")]);
+    let _lock = setup_env(vec![("TRAVIS", ""), ("TRAVIS_PULL_REQUEST", "false")]);
 
     let info = get();
 
@@ -967,7 +905,7 @@ fn get_no_pr_travis() {
 
 #[test]
 fn get_pr_travis() {
-    setup_env(vec![("TRAVIS", ""), ("TRAVIS_PULL_REQUEST", "123")]);
+    let _lock = setup_env(vec![("TRAVIS", ""), ("TRAVIS_PULL_REQUEST", "123")]);
 
     let info = get();
 
@@ -979,7 +917,7 @@ fn get_pr_travis() {
 
 #[test]
 fn get_pr2_travis() {
-    setup_env(vec![("TRAVIS", "")]);
+    let _lock = setup_env(vec![("TRAVIS", "")]);
 
     let info = get();
 
@@ -991,7 +929,7 @@ fn get_pr2_travis() {
 
 #[test]
 fn get_ziet_now() {
-    setup_env(vec![("NOW_BUILDER", "")]);
+    let _lock = setup_env(vec![("NOW_BUILDER", "")]);
 
     let info = get();
 
@@ -1003,7 +941,7 @@ fn get_ziet_now() {
 
 #[test]
 fn get_ci_unknown_1() {
-    setup_env(vec![("CI", "")]);
+    let _lock = setup_env(vec![("CI", "")]);
 
     let info = get();
 
@@ -1015,7 +953,7 @@ fn get_ci_unknown_1() {
 
 #[test]
 fn get_ci_unknown_2() {
-    setup_env(vec![("CONTINUOUS_INTEGRATION", "")]);
+    let _lock = setup_env(vec![("CONTINUOUS_INTEGRATION", "")]);
 
     let info = get();
 
@@ -1027,7 +965,7 @@ fn get_ci_unknown_2() {
 
 #[test]
 fn get_ci_unknown_3() {
-    setup_env(vec![("BUILD_NUMBER", "")]);
+    let _lock = setup_env(vec![("BUILD_NUMBER", "")]);
 
     let info = get();
 
@@ -1039,7 +977,7 @@ fn get_ci_unknown_3() {
 
 #[test]
 fn get_ci_unknown_4() {
-    setup_env(vec![("RUN_ID", "")]);
+    let _lock = setup_env(vec![("RUN_ID", "")]);
 
     let info = get();
 

--- a/src/ci_test.rs
+++ b/src/ci_test.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-use crate::test_env::setup_env;
+use crate::test_env::{get_with_env,setup_env};
 
 use std::env;
 
@@ -146,26 +146,22 @@ fn validate_contains_not_exists() {
 
 #[test]
 fn is_ci_test() {
-    let _lock = setup_env(vec![]);
+    let lock = setup_env(vec![]);
     let info = get();
     let ci = is_ci();
-
+    drop(lock);
     assert_eq!(info.ci, ci);
 }
 
 #[test]
 fn get_test() {
-    let _lock = setup_env(vec![]);
-    let info = get();
-
+    let info = get_with_env(vec![]);
     assert_eq!(info.name.is_some(), info.vendor.is_some());
 }
 
 #[test]
 fn get_no_pr_appveyor() {
-    let _lock = setup_env(vec![("APPVEYOR", "")]);
-
-    let info = get();
+    let info = get_with_env(vec![("APPVEYOR", "")]);
 
     assert!(info.ci);
     assert!(!info.pr.unwrap());
@@ -175,9 +171,7 @@ fn get_no_pr_appveyor() {
 
 #[test]
 fn get_pr_appveyor() {
-    let _lock = setup_env(vec![("APPVEYOR", ""), ("APPVEYOR_PULL_REQUEST_NUMBER", "")]);
-
-    let info = get();
+    let info = get_with_env(vec![("APPVEYOR", ""), ("APPVEYOR_PULL_REQUEST_NUMBER", "")]);
 
     assert!(info.ci);
     assert!(info.pr.unwrap());
@@ -187,9 +181,7 @@ fn get_pr_appveyor() {
 
 #[test]
 fn get_no_pr_azure_piplines() {
-    let _lock = setup_env(vec![("SYSTEM_TEAMFOUNDATIONCOLLECTIONURI", "")]);
-
-    let info = get();
+    let info = get_with_env(vec![("SYSTEM_TEAMFOUNDATIONCOLLECTIONURI", "")]);
 
     assert!(info.ci);
     assert!(!info.pr.unwrap());
@@ -199,12 +191,10 @@ fn get_no_pr_azure_piplines() {
 
 #[test]
 fn get_pr_azure_piplines() {
-    let _lock = setup_env(vec![
+    let info = get_with_env(vec![
         ("SYSTEM_TEAMFOUNDATIONCOLLECTIONURI", ""),
         ("SYSTEM_PULLREQUEST_PULLREQUESTID", ""),
     ]);
-
-    let info = get();
 
     assert!(info.ci);
     assert!(info.pr.unwrap());
@@ -214,9 +204,7 @@ fn get_pr_azure_piplines() {
 
 #[test]
 fn get_bamboo() {
-    let _lock = setup_env(vec![("bamboo_planKey", "")]);
-
-    let info = get();
+    let info = get_with_env(vec![("bamboo_planKey", "")]);
 
     assert!(info.ci);
     assert!(info.pr.is_none());
@@ -226,9 +214,7 @@ fn get_bamboo() {
 
 #[test]
 fn get_no_pr_bitbucket_piplines() {
-    let _lock = setup_env(vec![("BITBUCKET_COMMIT", "")]);
-
-    let info = get();
+    let info = get_with_env(vec![("BITBUCKET_COMMIT", "")]);
 
     assert!(info.ci);
     assert!(!info.pr.unwrap());
@@ -238,9 +224,7 @@ fn get_no_pr_bitbucket_piplines() {
 
 #[test]
 fn get_pr_bitbucket_piplines() {
-    let _lock = setup_env(vec![("BITBUCKET_COMMIT", ""), ("BITBUCKET_PR_ID", "")]);
-
-    let info = get();
+    let info = get_with_env(vec![("BITBUCKET_COMMIT", ""), ("BITBUCKET_PR_ID", "")]);
 
     assert!(info.ci);
     assert!(info.pr.unwrap());
@@ -250,21 +234,18 @@ fn get_pr_bitbucket_piplines() {
 
 #[test]
 fn get_no_pr_bitrise() {
-    let _lock = setup_env(vec![("BITRISE_IO", "")]);
-
-    let info = get();
+    let info = get_with_env(vec![("BITRISE_IO", "")]);
 
     assert!(info.ci);
     assert!(!info.pr.unwrap());
     assert_eq!(info.vendor.unwrap(), Vendor::Bitrise);
     assert_eq!(info.name.unwrap(), "Bitrise");
+
 }
 
 #[test]
 fn get_pr_bitrise() {
-    let _lock = setup_env(vec![("BITRISE_IO", ""), ("BITRISE_PULL_REQUEST", "")]);
-
-    let info = get();
+    let info = get_with_env(vec![("BITRISE_IO", ""), ("BITRISE_PULL_REQUEST", "")]);
 
     assert!(info.ci);
     assert!(info.pr.unwrap());
@@ -274,9 +255,7 @@ fn get_pr_bitrise() {
 
 #[test]
 fn get_no_pr_buddy() {
-    let _lock = setup_env(vec![("BUDDY_WORKSPACE_ID", "")]);
-
-    let info = get();
+    let info = get_with_env(vec![("BUDDY_WORKSPACE_ID", "")]);
 
     assert!(info.ci);
     assert!(!info.pr.unwrap());
@@ -286,12 +265,10 @@ fn get_no_pr_buddy() {
 
 #[test]
 fn get_pr_buddy() {
-    let _lock = setup_env(vec![
+    let info = get_with_env(vec![
         ("BUDDY_WORKSPACE_ID", ""),
         ("BUDDY_EXECUTION_PULL_REQUEST_ID", ""),
     ]);
-
-    let info = get();
 
     assert!(info.ci);
     assert!(info.pr.unwrap());
@@ -301,9 +278,7 @@ fn get_pr_buddy() {
 
 #[test]
 fn get_no_pr_buildkite() {
-    let _lock = setup_env(vec![("BUILDKITE", ""), ("BUILDKITE_PULL_REQUEST", "false")]);
-
-    let info = get();
+    let info = get_with_env(vec![("BUILDKITE", ""), ("BUILDKITE_PULL_REQUEST", "false")]);
 
     assert!(info.ci);
     assert!(!info.pr.unwrap());
@@ -313,9 +288,7 @@ fn get_no_pr_buildkite() {
 
 #[test]
 fn get_pr_buildkite() {
-    let _lock = setup_env(vec![("BUILDKITE", ""), ("BUILDKITE_PULL_REQUEST", "123")]);
-
-    let info = get();
+    let info = get_with_env(vec![("BUILDKITE", ""), ("BUILDKITE_PULL_REQUEST", "123")]);
 
     assert!(info.ci);
     assert!(info.pr.unwrap());
@@ -325,9 +298,7 @@ fn get_pr_buildkite() {
 
 #[test]
 fn get_pr2_buildkite() {
-    let _lock = setup_env(vec![("BUILDKITE", "")]);
-
-    let info = get();
+    let info = get_with_env(vec![("BUILDKITE", "")]);
 
     assert!(info.ci);
     assert!(info.pr.unwrap());
@@ -337,9 +308,7 @@ fn get_pr2_buildkite() {
 
 #[test]
 fn get_no_pr_circle_ci() {
-    let _lock = setup_env(vec![("CIRCLECI", "")]);
-
-    let info = get();
+    let info = get_with_env(vec![("CIRCLECI", "")]);
 
     assert!(info.ci);
     assert!(!info.pr.unwrap());
@@ -349,9 +318,7 @@ fn get_no_pr_circle_ci() {
 
 #[test]
 fn get_pr_circle_ci() {
-    let _lock = setup_env(vec![("CIRCLECI", ""), ("CIRCLE_PULL_REQUEST", "")]);
-
-    let info = get();
+    let info = get_with_env(vec![("CIRCLECI", ""), ("CIRCLE_PULL_REQUEST", "")]);
 
     assert!(info.ci);
     assert!(info.pr.unwrap());
@@ -361,9 +328,7 @@ fn get_pr_circle_ci() {
 
 #[test]
 fn get_no_pr_cirrus_ci() {
-    let _lock = setup_env(vec![("CIRRUS_CI", "")]);
-
-    let info = get();
+    let info = get_with_env(vec![("CIRRUS_CI", "")]);
 
     assert!(info.ci);
     assert!(!info.pr.unwrap());
@@ -373,9 +338,7 @@ fn get_no_pr_cirrus_ci() {
 
 #[test]
 fn get_pr_cirrus_ci() {
-    let _lock = setup_env(vec![("CIRRUS_CI", ""), ("CIRRUS_PR", "")]);
-
-    let info = get();
+    let info = get_with_env(vec![("CIRRUS_CI", ""), ("CIRRUS_PR", "")]);
 
     assert!(info.ci);
     assert!(info.pr.unwrap());
@@ -385,9 +348,7 @@ fn get_pr_cirrus_ci() {
 
 #[test]
 fn get_aws_codebuild() {
-    let _lock = setup_env(vec![("CODEBUILD_BUILD_ARN", "")]);
-
-    let info = get();
+    let info = get_with_env(vec![("CODEBUILD_BUILD_ARN", "")]);
 
     assert!(info.ci);
     assert!(info.pr.is_none());
@@ -397,9 +358,7 @@ fn get_aws_codebuild() {
 
 #[test]
 fn get_codeship() {
-    let _lock = setup_env(vec![("CI_NAME", "codeship")]);
-
-    let info = get();
+    let info = get_with_env(vec![("CI_NAME", "codeship")]);
 
     assert!(info.ci);
     assert!(info.pr.is_none());
@@ -409,9 +368,7 @@ fn get_codeship() {
 
 #[test]
 fn get_no_pr_drone() {
-    let _lock = setup_env(vec![("DRONE", "")]);
-
-    let info = get();
+    let info = get_with_env(vec![("DRONE", "")]);
 
     assert!(info.ci);
     assert!(!info.pr.unwrap());
@@ -421,9 +378,7 @@ fn get_no_pr_drone() {
 
 #[test]
 fn get_no_pr2_drone() {
-    let _lock = setup_env(vec![("DRONE", ""), ("DRONE_BUILD_EVENT", "test")]);
-
-    let info = get();
+    let info = get_with_env(vec![("DRONE", ""), ("DRONE_BUILD_EVENT", "test")]);
 
     assert!(info.ci);
     assert!(!info.pr.unwrap());
@@ -433,9 +388,7 @@ fn get_no_pr2_drone() {
 
 #[test]
 fn get_pr_drone() {
-    let _lock = setup_env(vec![("DRONE", ""), ("DRONE_BUILD_EVENT", "pull_request")]);
-
-    let info = get();
+    let info = get_with_env(vec![("DRONE", ""), ("DRONE_BUILD_EVENT", "pull_request")]);
 
     assert!(info.ci);
     assert!(info.pr.unwrap());
@@ -445,9 +398,7 @@ fn get_pr_drone() {
 
 #[test]
 fn get_dsari() {
-    let _lock = setup_env(vec![("DSARI", "")]);
-
-    let info = get();
+    let info = get_with_env(vec![("DSARI", "")]);
 
     assert!(info.ci);
     assert!(info.pr.is_none());
@@ -457,9 +408,7 @@ fn get_dsari() {
 
 #[test]
 fn get_no_pr_github_actions() {
-    let _lock = setup_env(vec![("GITHUB_ACTIONS", "")]);
-
-    let info = get();
+    let info = get_with_env(vec![("GITHUB_ACTIONS", "")]);
 
     assert!(info.ci);
     assert!(!info.pr.unwrap());
@@ -469,9 +418,7 @@ fn get_no_pr_github_actions() {
 
 #[test]
 fn get_no_pr2_github_actions() {
-    let _lock = setup_env(vec![("GITHUB_ACTIONS", ""), ("GITHUB_EVENT_NAME", "test")]);
-
-    let info = get();
+    let info = get_with_env(vec![("GITHUB_ACTIONS", ""), ("GITHUB_EVENT_NAME", "test")]);
 
     assert!(info.ci);
     assert!(!info.pr.unwrap());
@@ -481,12 +428,10 @@ fn get_no_pr2_github_actions() {
 
 #[test]
 fn get_pr_github_actions() {
-    let _lock = setup_env(vec![
+    let info = get_with_env(vec![
         ("GITHUB_ACTIONS", ""),
         ("GITHUB_EVENT_NAME", "pull_request"),
     ]);
-
-    let info = get();
 
     assert!(info.ci);
     assert!(info.pr.unwrap());
@@ -496,9 +441,7 @@ fn get_pr_github_actions() {
 
 #[test]
 fn get_gitlab_ci() {
-    let _lock = setup_env(vec![("GITLAB_CI", "")]);
-
-    let info = get();
+    let info = get_with_env(vec![("GITLAB_CI", "")]);
 
     assert!(info.ci);
     assert!(info.pr.is_none());
@@ -508,9 +451,7 @@ fn get_gitlab_ci() {
 
 #[test]
 fn get_gocd() {
-    let _lock = setup_env(vec![("GO_PIPELINE_LABEL", "")]);
-
-    let info = get();
+    let info = get_with_env(vec![("GO_PIPELINE_LABEL", "")]);
 
     assert!(info.ci);
     assert!(info.pr.is_none());
@@ -520,9 +461,7 @@ fn get_gocd() {
 
 #[test]
 fn get_heroku() {
-    let _lock = setup_env(vec![("NODE", "/app/.heroku/node/bin/node")]);
-
-    let info = get();
+    let info = get_with_env(vec![("NODE", "/app/.heroku/node/bin/node")]);
 
     assert!(info.ci);
     assert!(info.pr.is_none());
@@ -532,18 +471,14 @@ fn get_heroku() {
 
 #[test]
 fn get_heroku_not_ci() {
-    let _lock = setup_env(vec![("NODE", "test")]);
-
-    let info = get();
+    let info = get_with_env(vec![("NODE", "test")]);
 
     assert!(!info.ci);
 }
 
 #[test]
 fn get_hudson() {
-    let _lock = setup_env(vec![("HUDSON_URL", "")]);
-
-    let info = get();
+    let info = get_with_env(vec![("HUDSON_URL", "")]);
 
     assert!(info.ci);
     assert!(info.pr.is_none());
@@ -553,9 +488,7 @@ fn get_hudson() {
 
 #[test]
 fn get_no_pr_jenkins() {
-    let _lock = setup_env(vec![("JENKINS_URL", ""), ("BUILD_ID", "")]);
-
-    let info = get();
+    let info = get_with_env(vec![("JENKINS_URL", ""), ("BUILD_ID", "")]);
 
     assert!(info.ci);
     assert!(!info.pr.unwrap());
@@ -565,9 +498,7 @@ fn get_no_pr_jenkins() {
 
 #[test]
 fn get_partial1_jenkins() {
-    let _lock = setup_env(vec![("JENKINS_URL", "")]);
-
-    let info = get();
+    let info = get_with_env(vec![("JENKINS_URL", "")]);
 
     assert!(info.pr.is_none());
     assert!(info.vendor.is_none());
@@ -576,9 +507,7 @@ fn get_partial1_jenkins() {
 
 #[test]
 fn get_partial2_jenkins() {
-    let _lock = setup_env(vec![("BUILD_ID", "")]);
-
-    let info = get();
+    let info = get_with_env(vec![("BUILD_ID", "")]);
 
     assert!(info.pr.is_none());
     assert!(info.vendor.is_none());
@@ -587,13 +516,11 @@ fn get_partial2_jenkins() {
 
 #[test]
 fn get_pr_jenkins() {
-    let _lock = setup_env(vec![
+    let info = get_with_env(vec![
         ("JENKINS_URL", ""),
         ("BUILD_ID", ""),
         ("ghprbPullId", ""),
     ]);
-
-    let info = get();
 
     assert!(info.ci);
     assert!(info.pr.unwrap());
@@ -603,13 +530,11 @@ fn get_pr_jenkins() {
 
 #[test]
 fn get_pr2_jenkins() {
-    let _lock = setup_env(vec![
+    let info = get_with_env(vec![
         ("JENKINS_URL", ""),
         ("BUILD_ID", ""),
         ("CHANGE_ID", ""),
     ]);
-
-    let info = get();
 
     assert!(info.ci);
     assert!(info.pr.unwrap());
@@ -619,9 +544,7 @@ fn get_pr2_jenkins() {
 
 #[test]
 fn get_magnum_ci() {
-    let _lock = setup_env(vec![("MAGNUM", "")]);
-
-    let info = get();
+    let info = get_with_env(vec![("MAGNUM", "")]);
 
     assert!(info.ci);
     assert!(info.pr.is_none());
@@ -631,9 +554,7 @@ fn get_magnum_ci() {
 
 #[test]
 fn get_no_pr_netlify_ci() {
-    let _lock = setup_env(vec![("NETLIFY_BUILD_BASE", ""), ("PULL_REQUEST", "false")]);
-
-    let info = get();
+    let info = get_with_env(vec![("NETLIFY_BUILD_BASE", ""), ("PULL_REQUEST", "false")]);
 
     assert!(info.ci);
     assert!(!info.pr.unwrap());
@@ -643,9 +564,7 @@ fn get_no_pr_netlify_ci() {
 
 #[test]
 fn get_pr_netlify_ci() {
-    let _lock = setup_env(vec![("NETLIFY_BUILD_BASE", ""), ("PULL_REQUEST", "123")]);
-
-    let info = get();
+    let info = get_with_env(vec![("NETLIFY_BUILD_BASE", ""), ("PULL_REQUEST", "123")]);
 
     assert!(info.ci);
     assert!(info.pr.unwrap());
@@ -655,9 +574,7 @@ fn get_pr_netlify_ci() {
 
 #[test]
 fn get_pr2_netlify_ci() {
-    let _lock = setup_env(vec![("NETLIFY_BUILD_BASE", "")]);
-
-    let info = get();
+    let info = get_with_env(vec![("NETLIFY_BUILD_BASE", "")]);
 
     assert!(info.ci);
     assert!(info.pr.unwrap());
@@ -667,9 +584,7 @@ fn get_pr2_netlify_ci() {
 
 #[test]
 fn get_no_pr_nevercode_ci() {
-    let _lock = setup_env(vec![("NEVERCODE", ""), ("NEVERCODE_PULL_REQUEST", "false")]);
-
-    let info = get();
+    let info = get_with_env(vec![("NEVERCODE", ""), ("NEVERCODE_PULL_REQUEST", "false")]);
 
     assert!(info.ci);
     assert!(!info.pr.unwrap());
@@ -679,9 +594,7 @@ fn get_no_pr_nevercode_ci() {
 
 #[test]
 fn get_pr_nevercode_ci() {
-    let _lock = setup_env(vec![("NEVERCODE", ""), ("NEVERCODE_PULL_REQUEST", "123")]);
-
-    let info = get();
+    let info = get_with_env(vec![("NEVERCODE", ""), ("NEVERCODE_PULL_REQUEST", "123")]);
 
     assert!(info.ci);
     assert!(info.pr.unwrap());
@@ -691,9 +604,7 @@ fn get_pr_nevercode_ci() {
 
 #[test]
 fn get_pr2_nevercode_ci() {
-    let _lock = setup_env(vec![("NEVERCODE", "")]);
-
-    let info = get();
+    let info = get_with_env(vec![("NEVERCODE", "")]);
 
     assert!(info.ci);
     assert!(info.pr.unwrap());
@@ -703,9 +614,7 @@ fn get_pr2_nevercode_ci() {
 
 #[test]
 fn get_no_pr_render_ci() {
-    let _lock = setup_env(vec![("RENDER", "")]);
-
-    let info = get();
+    let info = get_with_env(vec![("RENDER", "")]);
 
     assert!(info.ci);
     assert!(!info.pr.unwrap());
@@ -715,9 +624,7 @@ fn get_no_pr_render_ci() {
 
 #[test]
 fn get_pr_render_ci() {
-    let _lock = setup_env(vec![("RENDER", ""), ("IS_PULL_REQUEST", "true")]);
-
-    let info = get();
+    let info = get_with_env(vec![("RENDER", ""), ("IS_PULL_REQUEST", "true")]);
 
     assert!(info.ci);
     assert!(info.pr.unwrap());
@@ -727,9 +634,7 @@ fn get_pr_render_ci() {
 
 #[test]
 fn get_no_pr_sail_ci() {
-    let _lock = setup_env(vec![("SAILCI", "")]);
-
-    let info = get();
+    let info = get_with_env(vec![("SAILCI", "")]);
 
     assert!(info.ci);
     assert!(!info.pr.unwrap());
@@ -739,9 +644,7 @@ fn get_no_pr_sail_ci() {
 
 #[test]
 fn get_pr_sail_ci() {
-    let _lock = setup_env(vec![("SAILCI", ""), ("SAIL_PULL_REQUEST_NUMBER", "")]);
-
-    let info = get();
+    let info = get_with_env(vec![("SAILCI", ""), ("SAIL_PULL_REQUEST_NUMBER", "")]);
 
     assert!(info.ci);
     assert!(info.pr.unwrap());
@@ -751,9 +654,7 @@ fn get_pr_sail_ci() {
 
 #[test]
 fn get_no_pr_semaphore() {
-    let _lock = setup_env(vec![("SEMAPHORE", "")]);
-
-    let info = get();
+    let info = get_with_env(vec![("SEMAPHORE", "")]);
 
     assert!(info.ci);
     assert!(!info.pr.unwrap());
@@ -763,9 +664,7 @@ fn get_no_pr_semaphore() {
 
 #[test]
 fn get_pr_semaphore() {
-    let _lock = setup_env(vec![("SEMAPHORE", ""), ("PULL_REQUEST_NUMBER", "")]);
-
-    let info = get();
+    let info = get_with_env(vec![("SEMAPHORE", ""), ("PULL_REQUEST_NUMBER", "")]);
 
     assert!(info.ci);
     assert!(info.pr.unwrap());
@@ -775,9 +674,7 @@ fn get_pr_semaphore() {
 
 #[test]
 fn get_no_pr_shippable() {
-    let _lock = setup_env(vec![("SHIPPABLE", "")]);
-
-    let info = get();
+    let info = get_with_env(vec![("SHIPPABLE", "")]);
 
     assert!(info.ci);
     assert!(!info.pr.unwrap());
@@ -787,9 +684,7 @@ fn get_no_pr_shippable() {
 
 #[test]
 fn get_no_pr2_shippable() {
-    let _lock = setup_env(vec![("SHIPPABLE", ""), ("IS_PULL_REQUEST", "123")]);
-
-    let info = get();
+    let info = get_with_env(vec![("SHIPPABLE", ""), ("IS_PULL_REQUEST", "123")]);
 
     assert!(info.ci);
     assert!(!info.pr.unwrap());
@@ -799,9 +694,7 @@ fn get_no_pr2_shippable() {
 
 #[test]
 fn get_pr_shippable() {
-    let _lock = setup_env(vec![("SHIPPABLE", ""), ("IS_PULL_REQUEST", "true")]);
-
-    let info = get();
+    let info = get_with_env(vec![("SHIPPABLE", ""), ("IS_PULL_REQUEST", "true")]);
 
     assert!(info.ci);
     assert!(info.pr.unwrap());
@@ -811,9 +704,7 @@ fn get_pr_shippable() {
 
 #[test]
 fn get_no_pr_solano_ci() {
-    let _lock = setup_env(vec![("TDDIUM", "")]);
-
-    let info = get();
+    let info = get_with_env(vec![("TDDIUM", "")]);
 
     assert!(info.ci);
     assert!(!info.pr.unwrap());
@@ -823,9 +714,7 @@ fn get_no_pr_solano_ci() {
 
 #[test]
 fn get_pr_solano_ci() {
-    let _lock = setup_env(vec![("TDDIUM", ""), ("TDDIUM_PR_ID", "")]);
-
-    let info = get();
+    let info = get_with_env(vec![("TDDIUM", ""), ("TDDIUM_PR_ID", "")]);
 
     assert!(info.ci);
     assert!(info.pr.unwrap());
@@ -835,9 +724,7 @@ fn get_pr_solano_ci() {
 
 #[test]
 fn get_strider_cd() {
-    let _lock = setup_env(vec![("STRIDER", "")]);
-
-    let info = get();
+    let info = get_with_env(vec![("STRIDER", "")]);
 
     assert!(info.ci);
     assert!(info.pr.is_none());
@@ -847,9 +734,7 @@ fn get_strider_cd() {
 
 #[test]
 fn get_taskcluster() {
-    let _lock = setup_env(vec![("TASK_ID", ""), ("RUN_ID", "")]);
-
-    let info = get();
+    let info = get_with_env(vec![("TASK_ID", ""), ("RUN_ID", "")]);
 
     assert!(info.ci);
     assert!(info.pr.is_none());
@@ -859,9 +744,7 @@ fn get_taskcluster() {
 
 #[test]
 fn get_partial1_taskcluster() {
-    let _lock = setup_env(vec![("TASK_ID", "")]);
-
-    let info = get();
+    let info = get_with_env(vec![("TASK_ID", "")]);
 
     assert!(info.pr.is_none());
     assert!(info.vendor.is_none());
@@ -870,9 +753,7 @@ fn get_partial1_taskcluster() {
 
 #[test]
 fn get_partial2_taskcluster() {
-    let _lock = setup_env(vec![("RUN_ID", "")]);
-
-    let info = get();
+    let info = get_with_env(vec![("RUN_ID", "")]);
 
     assert!(info.pr.is_none());
     assert!(info.vendor.is_none());
@@ -881,9 +762,7 @@ fn get_partial2_taskcluster() {
 
 #[test]
 fn get_teamcity() {
-    let _lock = setup_env(vec![("TEAMCITY_VERSION", "")]);
-
-    let info = get();
+    let info = get_with_env(vec![("TEAMCITY_VERSION", "")]);
 
     assert!(info.ci);
     assert!(info.pr.is_none());
@@ -893,9 +772,7 @@ fn get_teamcity() {
 
 #[test]
 fn get_no_pr_travis() {
-    let _lock = setup_env(vec![("TRAVIS", ""), ("TRAVIS_PULL_REQUEST", "false")]);
-
-    let info = get();
+    let info = get_with_env(vec![("TRAVIS", ""), ("TRAVIS_PULL_REQUEST", "false")]);
 
     assert!(info.ci);
     assert!(!info.pr.unwrap());
@@ -905,9 +782,7 @@ fn get_no_pr_travis() {
 
 #[test]
 fn get_pr_travis() {
-    let _lock = setup_env(vec![("TRAVIS", ""), ("TRAVIS_PULL_REQUEST", "123")]);
-
-    let info = get();
+    let info = get_with_env(vec![("TRAVIS", ""), ("TRAVIS_PULL_REQUEST", "123")]);
 
     assert!(info.ci);
     assert!(info.pr.unwrap());
@@ -917,9 +792,7 @@ fn get_pr_travis() {
 
 #[test]
 fn get_pr2_travis() {
-    let _lock = setup_env(vec![("TRAVIS", "")]);
-
-    let info = get();
+    let info = get_with_env(vec![("TRAVIS", "")]);
 
     assert!(info.ci);
     assert!(info.pr.unwrap());
@@ -929,9 +802,7 @@ fn get_pr2_travis() {
 
 #[test]
 fn get_ziet_now() {
-    let _lock = setup_env(vec![("NOW_BUILDER", "")]);
-
-    let info = get();
+    let info = get_with_env(vec![("NOW_BUILDER", "")]);
 
     assert!(info.ci);
     assert!(info.pr.is_none());
@@ -941,9 +812,7 @@ fn get_ziet_now() {
 
 #[test]
 fn get_ci_unknown_1() {
-    let _lock = setup_env(vec![("CI", "")]);
-
-    let info = get();
+    let info = get_with_env(vec![("CI", "")]);
 
     assert!(info.ci);
     assert!(info.pr.is_none());
@@ -953,9 +822,7 @@ fn get_ci_unknown_1() {
 
 #[test]
 fn get_ci_unknown_2() {
-    let _lock = setup_env(vec![("CONTINUOUS_INTEGRATION", "")]);
-
-    let info = get();
+    let info = get_with_env(vec![("CONTINUOUS_INTEGRATION", "")]);
 
     assert!(info.ci);
     assert!(info.pr.is_none());
@@ -965,9 +832,7 @@ fn get_ci_unknown_2() {
 
 #[test]
 fn get_ci_unknown_3() {
-    let _lock = setup_env(vec![("BUILD_NUMBER", "")]);
-
-    let info = get();
+    let info = get_with_env(vec![("BUILD_NUMBER", "")]);
 
     assert!(info.ci);
     assert!(info.pr.is_none());
@@ -977,9 +842,7 @@ fn get_ci_unknown_3() {
 
 #[test]
 fn get_ci_unknown_4() {
-    let _lock = setup_env(vec![("RUN_ID", "")]);
-
-    let info = get();
+    let info = get_with_env(vec![("RUN_ID", "")]);
 
     assert!(info.ci);
     assert!(info.pr.is_none());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -169,6 +169,9 @@ extern crate serde_derive;
 #[cfg(test)]
 #[path = "./lib_test.rs"]
 mod lib_test;
+#[cfg(test)]
+#[path = "./test_env.rs"]
+mod test_env;
 
 mod ci;
 mod config;

--- a/src/lib_test.rs
+++ b/src/lib_test.rs
@@ -1,7 +1,9 @@
 use super::*;
+use crate::test_env::setup_env;
 
 #[test]
 fn get_test() {
+    let _lock = setup_env(vec![]);
     let info = get();
 
     assert_eq!(info.ci, info.vendor.is_some());
@@ -9,6 +11,7 @@ fn get_test() {
 
 #[test]
 fn is_ci_test() {
+    let _lock = setup_env(vec![]);
     let info = get();
     let ci = is_ci();
 

--- a/src/lib_test.rs
+++ b/src/lib_test.rs
@@ -1,19 +1,18 @@
 use super::*;
-use crate::test_env::setup_env;
+use crate::test_env::{get_with_env,setup_env};
 
 #[test]
 fn get_test() {
-    let _lock = setup_env(vec![]);
-    let info = get();
+    let info = get_with_env(vec![]);
 
     assert_eq!(info.ci, info.vendor.is_some());
 }
 
 #[test]
 fn is_ci_test() {
-    let _lock = setup_env(vec![]);
+    let lock = setup_env(vec![]);
     let info = get();
     let ci = is_ci();
-
+    drop(lock);
     assert_eq!(info.ci, ci);
 }

--- a/src/test_env.rs
+++ b/src/test_env.rs
@@ -1,0 +1,81 @@
+use std::sync::{Mutex,MutexGuard};
+use lazy_static::lazy_static;
+use std::env;
+use envmnt;
+
+pub (crate) struct MutexInner;
+
+lazy_static! {
+    pub(crate) static ref ENVLOCK: Mutex<MutexInner> = {
+        Mutex::new(MutexInner)
+    };
+}
+
+#[inline(always)]
+pub (crate) fn setup_env(vars: Vec<(&str, &str)>) -> MutexGuard<'static, MutexInner>  {
+    let lock = ENVLOCK.lock().unwrap();
+    envmnt::remove_all(&vec![
+        "APPVEYOR",
+        "APPVEYOR_PULL_REQUEST_NUMBER",
+        "SYSTEM_TEAMFOUNDATIONCOLLECTIONURI",
+        "SYSTEM_PULLREQUEST_PULLREQUESTID",
+        "bamboo_planKey",
+        "BITBUCKET_COMMIT",
+        "BITBUCKET_PR_ID",
+        "BITRISE_IO",
+        "BITRISE_PULL_REQUEST",
+        "BUDDY_WORKSPACE_ID",
+        "BUDDY_EXECUTION_PULL_REQUEST_ID",
+        "BUILDKITE",
+        "BUILDKITE_PULL_REQUEST",
+        "CIRCLECI",
+        "CIRCLE_PULL_REQUEST",
+        "CIRRUS_CI",
+        "CIRRUS_PR",
+        "CODEBUILD_BUILD_ARN",
+        "CI_NAME",
+        "DRONE",
+        "DRONE_BUILD_EVENT",
+        "pull_request",
+        "DSARI",
+        "GITHUB_ACTIONS",
+        "GITHUB_EVENT_NAME",
+        "GITLAB_CI",
+        "GO_PIPELINE_LABEL",
+        "NODE",
+        "HUDSON_URL",
+        "JENKINS_URL",
+        "BUILD_ID",
+        "ghprbPullId",
+        "CHANGE_ID",
+        "MAGNUM",
+        "NETLIFY_BUILD_BASE",
+        "PULL_REQUEST",
+        "NEVERCODE",
+        "NEVERCODE_PULL_REQUEST",
+        "RENDER",
+        "SAILCI",
+        "SAIL_PULL_REQUEST_NUMBER",
+        "SEMAPHORE",
+        "PULL_REQUEST_NUMBER",
+        "SHIPPABLE",
+        "IS_PULL_REQUEST",
+        "TDDIUM",
+        "TDDIUM_PR_ID",
+        "STRIDER",
+        "TASK_ID",
+        "RUN_ID",
+        "TEAMCITY_VERSION",
+        "TRAVIS",
+        "TRAVIS_PULL_REQUEST",
+        "NOW_BUILDER",
+        "CI",
+        "CONTINUOUS_INTEGRATION",
+        "BUILD_NUMBER",
+    ]);
+
+    for env_var in vars {
+        env::set_var(env_var.0, env_var.1);
+    }
+    return lock;
+}

--- a/src/test_env.rs
+++ b/src/test_env.rs
@@ -11,6 +11,11 @@ lazy_static! {
     };
 }
 
+pub (crate) fn get_with_env(vars: Vec<(&str,&str)>) -> crate::CiInfo {
+    let _lock = setup_env(vars);
+    crate::get()
+}
+
 #[inline(always)]
 pub (crate) fn setup_env(vars: Vec<(&str, &str)>) -> MutexGuard<'static, MutexInner>  {
     let lock = ENVLOCK.lock().unwrap();


### PR DESCRIPTION
This is still a work-in-progress as it doesn't fix all the problems I'm seeing, but it certainly improves things.

Using lazy_static for now just to cut past the "what matters" aspect of this, in part, because I partially gave-up re-writing the lazy_static logic inline.

---

This makes each sub-test in ci_test claim a mutex lock prior
to tweaking ENV, which is then released only after the test exits,
removing the copious failures that occur without forcing single-threaded
testing.

Its still got some "odd" bugs that you'll see if you crank concurrency
up to 1000, and then run the test suite hundreds of times, but that's a
fair bit better than it was.

Though the places it fails needs further investigation, as when I
attempted to fix those problems with the same approach, lock() randomly
returned PoisonError's, which is probably bad.

Bug: https://github.com/sagiegurari/ci_info/issues/8