### PR TITLE
gitignore: ignore target as a symlink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 .idea
 .c9
-target/
+target
 temp/
 **/*.rs.bk
 Cargo.lock


### PR DESCRIPTION
---
Following rust-lang/cargo#4944.