### PR TITLE
Add iter feature to enable Vendor enum iteration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,8 @@ include = [
 envmnt = "^0.10"
 serde = { version = "1", optional = true }
 serde_derive = { version = "1", optional = true }
+strum = { version = "0.26", optional = true }
+strum_macros = { version = "0.26", optional = true }
 
 [dev-dependencies]
 doc-comment = "^0.3"
@@ -38,3 +40,4 @@ lazy_static = "^1"
 
 [features]
 serde-1 = ["serde", "serde_derive"]
+iter = ["strum", "strum_macros"]

--- a/README.md
+++ b/README.md
@@ -101,6 +101,44 @@ There is optional `serde` support that can be enabled via the `serde-1` feature:
 ci_info = { version = "*", features = ["serde-1"] }
 ```
 
+### Iterating Over Vendor Variants
+
+You can enable iteration over all `Vendor` enum variants by enabling `iter` feature:
+
+```ini
+[dependencies]
+ci_info = { version = "^0.14.14", features = ["iter"] }
+```
+
+This allows you to programmatically access all supported CI vendors:
+
+```rust
+use ci_info::types::Vendor;
+use strum::IntoEnumIterator;
+
+// List all supported CI vendors
+for vendor in Vendor::iter() {
+    println!("{:?}", vendor);
+}
+
+// Check how many vendors are supported
+let count = Vendor::iter().count();
+println!("Supporting {} CI vendors", count);
+
+// Filter for specific vendors
+let cloud_vendors: Vec<_> = Vendor::iter()
+    .filter(|v| matches!(v,
+        Vendor::GitHubActions |
+        Vendor::GitLabCI |
+        Vendor::CircleCI
+    ))
+    .collect();
+```
+
+**Note:** Iteration uses [strum](https://crates.io/crates/strum)'s `EnumIter` derive macro under a feature flag.
+
+Run complete example with: `cargo run --example iterate_vendors --features iter`
+
 ## API Documentation
 See full docs at: [API Docs](https://sagiegurari.github.io/ci_info/)
 

--- a/examples/iterate_vendors.rs
+++ b/examples/iterate_vendors.rs
@@ -1,0 +1,35 @@
+#[cfg(feature = "iter")]
+use strum::IntoEnumIterator;
+use ci_info::types::Vendor;
+
+fn main() {
+    #[cfg(not(feature = "iter"))]
+    {
+        eprintln!("Error: This example requires the 'iter' feature to be enabled.");
+        eprintln!("Run with: cargo run --example iterate_vendors --features iter");
+        std::process::exit(1);
+    }
+
+    #[cfg(feature = "iter")]
+    {
+        // List all supported CI vendors
+        println!("Supported CI vendors:");
+        for vendor in Vendor::iter() {
+            println!("  {:?}", vendor);
+        }
+
+        // Count total vendors
+        let count = Vendor::iter().count();
+        println!("\nTotal: {} vendors", count);
+
+        // Check if specific vendor is supported
+        let has_github = Vendor::iter().any(|v| matches!(v, Vendor::GitHubActions));
+        println!("GitHub Actions supported: {}", has_github);
+
+        // Filter for vendors containing "Git"
+        let git_vendors: Vec<_> = Vendor::iter()
+            .filter(|v| format!("{:?}", v).contains("Git"))
+            .collect();
+        println!("\nVendors with 'Git' in name: {:?}", git_vendors);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,6 +99,45 @@
 //! ci_info = { version = "*", features = ["serde-1"] }
 //! ```
 //!
+//! ## Iterating Over Vendor Variants (Optional Feature)
+//!
+//! When `iter` feature is enabled, you can iterate over all known CI vendor variants:
+//!
+//! ```toml
+//! [dependencies]
+//! ci_info = { version = "*", features = ["iter"] }
+//! ```
+//!
+//! Example usage:
+//!
+//! ```rust
+//! # #[cfg(feature = "iter")]
+//! # {
+//! use ci_info::types::Vendor;
+//! use strum::IntoEnumIterator;
+//!
+//! // List all supported CI vendors
+//! for vendor in Vendor::iter() {
+//!     println!("Supported CI vendor: {:?}", vendor);
+//! }
+//!
+//! // Count vendors
+//! let vendor_count = Vendor::iter().count();
+//! println!("Total CI vendors supported: {}", vendor_count);
+//!
+//! // Filter for specific vendors
+//! let cloud_vendors: Vec<_> = Vendor::iter()
+//!     .filter(|v| matches!(v,
+//!         Vendor::GitHubActions |
+//!         Vendor::GitLabCI |
+//!         Vendor::CircleCI
+//!     ))
+//!     .collect();
+//! # }
+//! ```
+//!
+//! This feature uses [strum](https://crates.io/crates/strum) library's `EnumIter` derive macro.
+//!
 //! # Contributing
 //! See [contributing guide](https://github.com/sagiegurari/ci_info/blob/master/.github/CONTRIBUTING.md)
 //!

--- a/src/types.rs
+++ b/src/types.rs
@@ -8,6 +8,7 @@
 mod types_test;
 
 #[cfg_attr(feature = "serde-1", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "iter", derive(strum_macros::EnumIter, Eq, Hash))]
 #[derive(Debug, Clone, PartialEq, Copy)]
 #[non_exhaustive]
 /// Supported vendors enum

--- a/src/types_test.rs
+++ b/src/types_test.rs
@@ -10,3 +10,129 @@ fn ci_info_new() {
     assert!(info.pr.is_none());
     assert!(info.branch_name.is_none());
 }
+
+// ===== Iterator Feature Tests =====
+// These tests verify Vendor enum iteration functionality when iter feature is enabled
+
+#[test]
+#[cfg(feature = "iter")]
+fn vendor_iter_basic() {
+    use strum::IntoEnumIterator;
+
+    let variants: Vec<Vendor> = Vendor::iter().collect();
+    assert!(
+        !variants.is_empty(),
+        "Iterator should produce at least one variant"
+    );
+}
+
+#[test]
+#[cfg(feature = "iter")]
+fn vendor_iter_count() {
+    use strum::IntoEnumIterator;
+
+    // Update this constant when adding or removing variants
+    // This test will fail if Vendor enum changes, prompting developer to verify all changes
+    const EXPECTED_VARIANT_COUNT: usize = 51;
+    let actual_count = Vendor::iter().count();
+
+    assert_eq!(
+        actual_count, EXPECTED_VARIANT_COUNT,
+        "Vendor enum has {} variants but expected {}. \
+         Did you add/remove variants? Update EXPECTED_VARIANT_COUNT in this test.",
+        actual_count, EXPECTED_VARIANT_COUNT
+    );
+}
+
+#[test]
+#[cfg(feature = "iter")]
+fn vendor_iter_uniqueness() {
+    use std::collections::HashSet;
+    use strum::IntoEnumIterator;
+
+    let variants: Vec<Vendor> = Vendor::iter().collect();
+    let unique: HashSet<_> = variants.iter().collect();
+
+    assert_eq!(
+        variants.len(),
+        unique.len(),
+        "Iterator produced duplicate variants"
+    );
+}
+
+#[test]
+#[cfg(feature = "iter")]
+fn vendor_iter_contains_known_vendors() {
+    use strum::IntoEnumIterator;
+
+    let variants: Vec<Vendor> = Vendor::iter().collect();
+
+    // Verify some well-known CI vendors are included in iteration
+    // This catches potential issues where specific variants might be accidentally excluded
+    assert!(
+        variants.contains(&Vendor::GitHubActions),
+        "GitHubActions should be in iterator"
+    );
+    assert!(
+        variants.contains(&Vendor::GitLabCI),
+        "GitLabCI should be in iterator"
+    );
+    assert!(
+        variants.contains(&Vendor::CircleCI),
+        "CircleCI should be in iterator"
+    );
+    assert!(
+        variants.contains(&Vendor::TravisCI),
+        "TravisCI should be in iterator"
+    );
+    assert!(
+        variants.contains(&Vendor::Unknown),
+        "Unknown variant should be in iterator"
+    );
+}
+
+#[test]
+#[cfg(feature = "iter")]
+fn vendor_iter_copy_semantics() {
+    use strum::IntoEnumIterator;
+
+    // Vendor implements Copy, so iterator should work without .cloned()
+    // This verifies Copy semantics are preserved with iterator
+    let first_pass: Vec<Vendor> = Vendor::iter().collect();
+    let second_pass: Vec<Vendor> = Vendor::iter().collect();
+
+    assert_eq!(
+        first_pass, second_pass,
+        "Multiple iterations should produce identical results"
+    );
+}
+
+#[test]
+#[cfg(feature = "iter")]
+fn vendor_iter_functional_operations() {
+    use strum::IntoEnumIterator;
+
+    // Demonstrate practical usage patterns - filtering, mapping, etc.
+    let github_or_gitlab: Vec<Vendor> = Vendor::iter()
+        .filter(|v| matches!(v, Vendor::GitHubActions | Vendor::GitLabCI))
+        .collect();
+
+    assert_eq!(github_or_gitlab.len(), 2, "Should find exactly 2 variants");
+    assert!(github_or_gitlab.contains(&Vendor::GitHubActions));
+    assert!(github_or_gitlab.contains(&Vendor::GitLabCI));
+}
+
+#[test]
+#[cfg(feature = "iter")]
+fn vendor_iter_debug_formatting() {
+    use strum::IntoEnumIterator;
+
+    // Verify all variants can be debug-formatted (useful for logging/debugging)
+    for vendor in Vendor::iter() {
+        let debug_str = format!("{:?}", vendor);
+        assert!(
+            !debug_str.is_empty(),
+            "Debug formatting should produce non-empty string"
+        );
+    }
+}

--- a/tests/iter_test.rs
+++ b/tests/iter_test.rs
@@ -1,0 +1,131 @@
+//! Integration tests for Vendor enum iteration feature
+//!
+//! These tests verify iteration works correctly from external crate perspective,
+//! ensuring public API is properly exposed when iter feature is enabled.
+
+#[cfg(feature = "iter")]
+mod iter_tests {
+    use ci_info::types::Vendor;
+    use strum::IntoEnumIterator;
+
+    #[test]
+    fn can_iterate_all_vendors() {
+        let count = Vendor::iter().count();
+
+        // We expect to support many CI vendors (50+)
+        // This test will catch if iteration somehow produces very few variants
+        assert!(
+            count > 50,
+            "Expected many CI vendors (50+), but got {}. \
+             Check if EnumIter derive is working correctly.",
+            count
+        );
+    }
+
+    #[test]
+    fn iteration_is_deterministic() {
+        // Iteration order should be consistent across multiple calls
+        // This is important for reproducible behavior in applications
+        let first: Vec<_> = Vendor::iter().collect();
+        let second: Vec<_> = Vendor::iter().collect();
+
+        assert_eq!(
+            first, second,
+            "Iterator should produce same order across multiple invocations"
+        );
+    }
+
+    #[test]
+    fn can_collect_into_various_containers() {
+        use std::collections::HashSet;
+
+        // Verify iterator works with different collection types
+        let vec: Vec<_> = Vendor::iter().collect();
+        let hashset: HashSet<_> = Vendor::iter().collect();
+
+        assert_eq!(vec.len(), hashset.len(), "All variants should be unique");
+    }
+
+    #[test]
+    fn iteration_with_chaining() {
+        // Demonstrate that iterator can be chained with other operations
+        let non_unknown_count = Vendor::iter()
+            .filter(|v| !matches!(v, Vendor::Unknown))
+            .count();
+
+        let total_count = Vendor::iter().count();
+
+        // Unknown variant exists, so filtered count should be one less
+        assert_eq!(
+            non_unknown_count,
+            total_count - 1,
+            "Filtering out Unknown should reduce count by 1"
+        );
+    }
+
+    #[test]
+    fn iteration_supports_find() {
+        // Demonstrate find operation works on iterator
+        let github_actions = Vendor::iter()
+            .find(|v| matches!(v, Vendor::GitHubActions));
+
+        assert!(
+            github_actions.is_some(),
+            "Should be able to find GitHubActions variant"
+        );
+        assert_eq!(github_actions.unwrap(), Vendor::GitHubActions);
+    }
+
+    #[test]
+    fn iteration_supports_any() {
+        // Demonstrate any() predicate works
+        let has_gitlab = Vendor::iter()
+            .any(|v| matches!(v, Vendor::GitLabCI));
+
+        assert!(has_gitlab, "Iterator should contain GitLabCI");
+    }
+
+    #[test]
+    fn iteration_supports_all() {
+        // Demonstrate all() predicate works
+        let all_are_vendors = Vendor::iter()
+            .all(|_v| true); // All variants are valid Vendor types
+
+        assert!(all_are_vendors, "All items should be Vendor variants");
+    }
+
+    #[test]
+    fn debug_print_all_vendors() {
+        // Useful for manual verification during code review
+        // Also verifies Debug trait works with all variants
+        println!("\n=== All Supported CI Vendors ===");
+        for (idx, vendor) in Vendor::iter().enumerate() {
+            println!("{}. {:?}", idx + 1, vendor);
+        }
+        println!("Total: {} vendors\n", Vendor::iter().count());
+    }
+
+    #[test]
+    fn iteration_works_with_partition() {
+        // Demonstrate partition operation
+        let (cloud_based, others): (Vec<_>, Vec<_>) = Vendor::iter()
+            .partition(|v| matches!(
+                v,
+                Vendor::GitHubActions
+                    | Vendor::GitLabCI
+                    | Vendor::CircleCI
+                    | Vendor::AzurePipelines
+                    | Vendor::AWSCodeBuild
+                    | Vendor::GoogleCloudBuild
+            ));
+
+        assert!(
+            !cloud_based.is_empty(),
+            "Should identify some cloud-based CI vendors"
+        );
+        assert!(
+            !others.is_empty(),
+            "Should have non-cloud-based vendors too"
+        );
+    }
+}


### PR DESCRIPTION
Implements #20: Add support for iterating over all Vendor enum variants.

This adds an optional 'iter' feature that enables programmatic iteration over all supported CI vendor variants using strum's EnumIter derive macro.

Changes:
- Added 'iter' feature with strum dependencies (strum 0.26)
- Added `EnumIter` derive to `enum Vendor` (conditional on iter feature)
- Added `Eq` and `Hash` traits to `Vendor` behind same feature flag `iter` (required for HashSet in tests)
- Added 7 unit tests in `src/types_test.rs`
- Added 9 integration tests in `tests/iter_test.rs`
- Added ./examples/iterate_vendors.rs demonstrating usage
- Updated ./README.md and ./src/lib.rs documentation

Example:
```rust
use ci_info::types::Vendor;
use strum::IntoEnumIterator;
for vendor in Vendor::iter() {
    println!("{:?}", vendor);
}
```